### PR TITLE
android ndk requires arch to be arm not armv7

### DIFF
--- a/dist-build/android-armv7.sh
+++ b/dist-build/android-armv7.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a"
-TARGET_ARCH=armv7 HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"
+TARGET_ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
In the android-build.sh script, the call the ${ANDROID_NDK_HOME}/build/tools/make-standalone-toolchain.sh passes TARGET_ARCH as armv7 where as around line 117 of make-standalone-toolchain.sh requires ARCH to be {arm,x86,mips,arm64,x86_64,mips64}