### PR TITLE
Add systemd_notify wrapper on sd_notify.

### DIFF
--- a/src/proxy/app.c
+++ b/src/proxy/app.c
@@ -235,9 +235,7 @@ dnscrypt_proxy_start_listeners(ProxyContext * const proxy_context)
     logger(proxy_context, LOG_NOTICE, "Proxying from %s to %s",
            local_addr_s, resolver_addr_s);
     proxy_context->listeners_started = 1;
-#ifdef HAVE_LIBSYSTEMD
-    sd_notify(0, "READY=1");
-#endif
+    systemd_notify(proxy_context, "READY=1");
     return 0;
 }
 
@@ -373,9 +371,7 @@ dnscrypt_proxy_main(int argc, char *argv[])
         event_base_dispatch(proxy_context.event_loop);
     }
     logger_noformat(&proxy_context, LOG_NOTICE, "Stopping proxy");
-#ifdef HAVE_LIBSYSTEMD
-    sd_notify(0, "STOPPING=1");
-#endif
+    systemd_notify(0, "STOPPING=1");
 
     cert_updater_free(&proxy_context);
     udp_listener_stop(&proxy_context);

--- a/src/proxy/logger.c
+++ b/src/proxy/logger.c
@@ -13,6 +13,11 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef HAVE_LIBSYSTEMD
+# include <sys/socket.h>
+# include <systemd/sd-daemon.h>
+#endif
+
 #include <event2/util.h>
 
 #include "dnscrypt_proxy.h"
@@ -132,6 +137,16 @@ logger_error(struct ProxyContext_ * const context,
     const char *const err_msg = strerror(errno);
 
     return logger(context, LOG_ERR, "%s: %s", msg, err_msg);
+}
+
+void systemd_notify(struct ProxyContext_ * const context,
+                    const char * msg) {
+#ifdef HAVE_LIBSYSTEMD
+    int err = sd_notify(0, msg);
+    if (err < 0) {
+        logger(context, LOG_DEBUG, "sd_notify failed: %s", strerror(-err));
+    }
+#endif
 }
 
 int

--- a/src/proxy/logger.h
+++ b/src/proxy/logger.h
@@ -51,6 +51,9 @@ int logger_noformat(struct ProxyContext_ * const context,
 int logger_error(struct ProxyContext_ * const context,
                  const char * const msg);
 
+void systemd_notify(struct ProxyContext_ * const context,
+                    const char * const msg);
+
 int logger_close(struct ProxyContext_ * const context);
 
 #endif


### PR DESCRIPTION
Move the logic for calling sd_notify into its own function and do better
logging of errors returned.