### PR TITLE
Add systemd unit to debian package

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -2,7 +2,8 @@ Source: dnscrypt-proxy
 Section: net
 Priority: optional
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 9), automake, autotools-dev, libsodium-dev
+Build-Depends: debhelper (>= 9), automake, autotools-dev, libsodium-dev,
+               dh-systemd (>= 1.5)
 Standards-Version: 3.9.5
 Homepage: http://dnscrypt.org
 Vcs-Git: git://github.com/jedisct1/dnscrypt-proxy.git

--- a/packages/debian/control
+++ b/packages/debian/control
@@ -2,7 +2,7 @@ Source: dnscrypt-proxy
 Section: net
 Priority: optional
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 9), autotools-dev, libsodium-dev
+Build-Depends: debhelper (>= 9), automake, autotools-dev, libsodium-dev
 Standards-Version: 3.9.5
 Homepage: http://dnscrypt.org
 Vcs-Git: git://github.com/jedisct1/dnscrypt-proxy.git

--- a/packages/debian/dnscrypt-proxy.init
+++ b/packages/debian/dnscrypt-proxy.init
@@ -51,6 +51,9 @@ case "$1" in
 	    log_end_msg 1
 	fi
 
+	# Pre-start setup shared across all init systems
+	/usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
+
 	params="$(grep -v '^#' $CONF | cut -d '#' -f 1 | grep -v 'resolvconf')"
 	for parameter in $params; do
 	    test -n "$parameter" && OPTIONS="$OPTIONS --$parameter"
@@ -58,22 +61,13 @@ case "$1" in
 
 	if start-stop-daemon --start --background --oknodo --quiet --exec /usr/sbin/dnscrypt-proxy \
 		--pidfile ${PIDFILE} -- $OPTIONS; then
-		if [ "X$resolvconf" != "Xno" ] && [ -x /sbin/resolvconf ] ; then
-			local_address=$(grep '^local-address' $CONF | head -n 1 | cut -d '=' -f 2)
-			# Strip the port from local address; different codepath for IPv6
-			if (echo "$local_address" | grep -q ']'); then
-				local_address=$(echo "$local_address" | cut -d ']' -f 1)']'
-			else
-				local_address=$(echo "$local_address" | cut -d ':' -f 1)
-			fi
-			echo "nameserver ${local_address:-127.0.0.1}" \
-			| /sbin/resolvconf -a lo.dnscrypt
-	    fi
-	    log_end_msg 0
+		/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-start
+		# the script is smart and will figure out whether resolvconf is enabled on its own
+		log_end_msg 0
 	else
-	    log_end_msg 1
+		log_end_msg 1
 	fi
-    ;;
+	;;
 
     stop)
 	log_daemon_msg "Stopping domain name proxy service..." "dnscrypt-proxy"
@@ -82,9 +76,8 @@ case "$1" in
 	    log_end_msg 1
 	fi
 
-	if [ "X$resolvconf" != "Xno" ] && [ -x /sbin/resolvconf ] ; then
-	    /sbin/resolvconf -d lo.dnscrypt
-	fi
+	/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-stop
+	# the script is smart and will figure out whether resolvconf is enabled on its own
 	pid=$(pgrep --newest -f ^/usr/sbin/dnscrypt-proxy) || true
 	start-stop-daemon --stop --oknodo --quiet --exec /usr/sbin/dnscrypt-proxy \
 	    --pidfile ${PIDFILE} -- $OPTIONS

--- a/packages/debian/dnscrypt-proxy.init
+++ b/packages/debian/dnscrypt-proxy.init
@@ -66,7 +66,7 @@ case "$1" in
 			else
 				local_address=$(echo "$local_address" | cut -d ':' -f 1)
 			fi
-			echo "nameserver ${local_address:-127.0.0.1}"
+			echo "nameserver ${local_address:-127.0.0.1}" \
 			| /sbin/resolvconf -a lo.dnscrypt
 	    fi
 	    log_end_msg 0

--- a/packages/debian/dnscrypt-proxy.service
+++ b/packages/debian/dnscrypt-proxy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=DNSCrypt client proxy
+Wants=network.target
+After=network.target
+ExecStartPre=/usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
+ExecStartPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-start
+ExecStopPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-stop
+
+[Service]
+Type=simple
+Restart=always
+RestartPreventExitStatus=1
+PermissionsStartOnly=true
+ProtectHome=true
+ProtectSystem=full
+ExecStart=/usr/lib/dnscrypt-proxy/init-system-wrappers/read-config-and-start
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/debian/dnscrypt-proxy.service
+++ b/packages/debian/dnscrypt-proxy.service
@@ -2,9 +2,6 @@
 Description=DNSCrypt client proxy
 Wants=network.target
 After=network.target
-ExecStartPre=/usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
-ExecStartPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-start
-ExecStopPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-stop
 
 [Service]
 Type=simple
@@ -13,7 +10,10 @@ RestartPreventExitStatus=1
 PermissionsStartOnly=true
 ProtectHome=true
 ProtectSystem=full
+ExecStartPre=/usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
 ExecStart=/usr/lib/dnscrypt-proxy/init-system-wrappers/read-config-and-start
+ExecStartPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-start
+ExecStopPost=/usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-stop
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/debian/dnscrypt-proxy.upstart
+++ b/packages/debian/dnscrypt-proxy.upstart
@@ -3,47 +3,10 @@ description "dnscrypt-proxy startup script"
 start on (local-filesystems and net-device-up IFACE=lo)
 stop on runlevel [!2345]
 
-pre-start script
-    # This is the home dir of user "dnscrypt"
-    # dnscrypt-proxy will chroot there for security reasons
-    mkdir -p /run/dnscrypt
+pre-start exec /usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
 
-    #Load the AppArmor profile, otherwise it wouldn't be applied
-    /lib/init/apparmor-profile-load usr.sbin.dnscrypt-proxy || true
-end script
+exec /usr/lib/dnscrypt-proxy/init-system-wrappers/read-config-and-start
 
-script
-    conffile="/etc/default/dnscrypt-proxy"
-    if test ! -r "$conffile"; then
-        echo "Could not read config file at $conffile"'!'
-        exit 1
-    else
-        params="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep -v '^resolvconf')"
-        for parameter in $params; do
-            test -n "$parameter" && options="$options --$parameter"
-        done
-        exec /usr/sbin/dnscrypt-proxy $options
-    fi
-end script
+post-start exec /usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-start
 
-post-start script
-    conffile="/etc/default/dnscrypt-proxy"
-    resolvconf="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep '^resolvconf'| cut -d '=' -f 2-)"
-    if test "X$resolvconf" != "Xno" && test -x /sbin/resolvconf && test -L /etc/resolv.conf; then
-        local_address="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep '^local-address'| cut -d '=' -f 2-)"
-        # Strip the port from local address; different codepath for IPv6
-        if (echo "$local_address" | grep -q ']'); then
-            local_address=$(echo "$local_address" | cut -d ']' -f 1)']'
-        else
-            local_address=$(echo "$local_address" | cut -d ':' -f 1)
-        fi
-        # if no local address specified, fall back to 127.0.0.1:53 (internal dnscrypt default)
-        echo "nameserver ${local_address:-127.0.0.1}" | /sbin/resolvconf -a lo.dnscrypt
-    fi
-end script
-
-post-stop script
-    if test -x /sbin/resolvconf; then
-        /sbin/resolvconf -d lo.dnscrypt
-    fi
-end script
+post-stop exec /usr/lib/dnscrypt-proxy/init-system-wrappers/update-resolvconf-on-stop

--- a/packages/debian/dnscrypt-proxy.upstart
+++ b/packages/debian/dnscrypt-proxy.upstart
@@ -2,6 +2,8 @@ description "dnscrypt-proxy startup script"
 
 start on (local-filesystems and net-device-up IFACE=lo)
 stop on runlevel [!2345]
+respawn
+respawn limit 3 60
 
 pre-start exec /usr/lib/dnscrypt-proxy/init-system-wrappers/pre-start-hooks
 

--- a/packages/debian/init-system-wrappers/pre-start-hooks
+++ b/packages/debian/init-system-wrappers/pre-start-hooks
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# This is the home dir of user "dnscrypt"
+# dnscrypt-proxy will chroot there for security reasons
+mkdir -p /run/dnscrypt
+
+#Load the AppArmor profile, otherwise it wouldn't be applied
+/lib/init/apparmor-profile-load usr.sbin.dnscrypt-proxy || true

--- a/packages/debian/init-system-wrappers/read-config-and-start
+++ b/packages/debian/init-system-wrappers/read-config-and-start
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+conffile="/etc/default/dnscrypt-proxy"
+if test ! -r "$conffile"; then
+    echo "Could not read config file at $conffile"'!'
+    exit 1
+else
+    params="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep -v '^resolvconf')"
+    for parameter in $params; do
+        test -n "$parameter" && options="$options --$parameter"
+    done
+    exec /usr/sbin/dnscrypt-proxy $options
+fi

--- a/packages/debian/init-system-wrappers/update-resolvconf-on-start
+++ b/packages/debian/init-system-wrappers/update-resolvconf-on-start
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+conffile="/etc/default/dnscrypt-proxy"
+resolvconf="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep '^resolvconf'| cut -d '=' -f 2-)"
+if test "X$resolvconf" != "Xno" && test -x /sbin/resolvconf && test -L /etc/resolv.conf; then
+    local_address="$(grep -v '^#' $conffile | cut -d '#' -f 1 | grep '^local-address'| cut -d '=' -f 2-)"
+    # Strip the port from local address; different codepath for IPv6
+    if (echo "$local_address" | grep -q ']'); then
+        local_address=$(echo "$local_address" | cut -d ']' -f 1)']'
+    else
+        local_address=$(echo "$local_address" | cut -d ':' -f 1)
+    fi
+    # if no local address specified, fall back to 127.0.0.1:53 (internal dnscrypt default)
+    echo "nameserver ${local_address:-127.0.0.1}" | /sbin/resolvconf -a lo.dnscrypt
+fi

--- a/packages/debian/init-system-wrappers/update-resolvconf-on-stop
+++ b/packages/debian/init-system-wrappers/update-resolvconf-on-stop
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+if test -x /sbin/resolvconf; then
+    /sbin/resolvconf -d lo.dnscrypt
+fi

--- a/packages/debian/install
+++ b/packages/debian/install
@@ -1,0 +1,1 @@
+debian/init-system-wrappers/* /usr/lib/dnscrypt-proxy/init-system-wrappers/

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -10,7 +10,9 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@  --with autotools-dev
+	dh $@  --with autotools-dev --with systemd
+	#for legacy systems without dh-systemd package use this instead:
+	#dh $@  --with autotools-dev
 
 override_dh_auto_configure:
 	dh_auto_configure -- --disable-ltdl-install --without-included-ltdl


### PR DESCRIPTION
* Split shared code out of Upstart script into standalone shell scripts
* Drop some duplicated code from sysvinit script and use the shared wrappers instead (this also fixes a dreadful bug in sysvinit script that I've introduced in the previous merge request)
* Add systemd unit using said wrappers to the package for proper support of Ubuntu 15.04 and Debian Jessie
* Add auto-respawning of DNSCrypt in case of crashes to upstart and systemd configs (but not on permanent failures like missing conffile).

I've tested DNSCrypt with all three init systems this time.