### PR TITLE
Enable SO_REUSEPORT

### DIFF
--- a/src/libevent-modified/evutil.c
+++ b/src/libevent-modified/evutil.c
@@ -347,6 +347,20 @@ evutil_make_listen_socket_reuseable(evutil_socket_t sock)
 }
 
 int
+evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
+{
+#if defined __linux__ && defined(SO_REUSEPORT)
+	int one = 1;
+	/* REUSEPORT on Linux 3.9+ means, "Multiple servers (processes or
+	 * threads) can bind to the same port if they each set the option. */
+	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void*) &one,
+	    (ev_socklen_t)sizeof(one));
+#else
+	return 0;
+#endif
+}
+
+int
 evutil_make_socket_closeonexec(evutil_socket_t fd)
 {
 #if !defined(WIN32)

--- a/src/libevent-modified/include/event2/listener.h
+++ b/src/libevent-modified/include/event2/listener.h
@@ -69,6 +69,15 @@ typedef void (*evconnlistener_errorcb)(struct evconnlistener *, void *);
 /** Flag: Indicates that the listener should be locked so it's safe to use
  * from multiple threadcs at once. */
 #define LEV_OPT_THREADSAFE		(1u<<4)
+/** Flag: Indicates that we ask to allow multiple servers (processes or
+ * threads) to bind to the same port if they each set the option.
+ *
+ * SO_REUSEPORT is what most people would expect SO_REUSEADDR to be, however
+ * SO_REUSEPORT does not imply SO_REUSEADDR.
+ *
+ * This is only available on Linux and kernel 3.9+
+ */
+#define LEV_OPT_REUSEABLE_PORT		(1u<<7)
 
 /**
    Allocate a new evconnlistener object to listen for incoming TCP connections

--- a/src/libevent-modified/include/event2/util.h
+++ b/src/libevent-modified/include/event2/util.h
@@ -306,6 +306,18 @@ int evutil_make_socket_nonblocking(evutil_socket_t sock);
  */
 int evutil_make_listen_socket_reuseable(evutil_socket_t sock);
 
+/** Do platform-specific operations to make a listener port reusable.
+
+    Specifically, we want to make sure that multiple programs which also
+    set the same socket option will be able to bind, listen at the same time.
+
+    This is a feature available only to Linux 3.9+
+
+    @param sock The socket to make reusable
+    @return 0 on success, -1 on failure
+*/
+int evutil_make_listen_socket_reuseable_port(evutil_socket_t sock);
+
 /** Do platform-specific operations as needed to close a socket upon a
     successful execution of one of the exec*() functions.
 

--- a/src/libevent-modified/listener.c
+++ b/src/libevent-modified/listener.c
@@ -236,6 +236,10 @@ evconnlistener_new_bind(struct event_base *base, evconnlistener_cb cb,
 			return NULL;
 		}
 	}
+	if (flags & LEV_OPT_REUSEABLE_PORT) {
+		if (evutil_make_listen_socket_reuseable_port(fd) < 0)
+			return NULL;
+	}
 
 	if (sa) {
 		if (bind(fd, sa, socklen)<0) {

--- a/src/proxy/tcp_request.c
+++ b/src/proxy/tcp_request.c
@@ -557,6 +557,7 @@ tcp_listener_bind(ProxyContext * const proxy_context)
                                     LEV_OPT_CLOSE_ON_FREE |
                                     LEV_OPT_CLOSE_ON_EXEC |
                                     LEV_OPT_REUSEABLE |
+                                    LEV_OPT_REUSEABLE_PORT |
                                     LEV_OPT_DEFERRED_ACCEPT,
                                     TCP_REQUEST_BACKLOG,
                                     (struct sockaddr *)

--- a/src/proxy/udp_request.c
+++ b/src/proxy/udp_request.c
@@ -481,6 +481,7 @@ udp_listener_kill_oldest_request(ProxyContext * const proxy_context)
 int
 udp_listener_bind(ProxyContext * const proxy_context)
 {
+    int optval = 1;
     if (proxy_context->udp_listener_handle == -1) {
         if ((proxy_context->udp_listener_handle = socket
              (proxy_context->local_sockaddr.ss_family,
@@ -489,6 +490,7 @@ udp_listener_bind(ProxyContext * const proxy_context)
                             "Unable to create a socket (UDP)");
             return -1;
         }
+        setsockopt(proxy_context->udp_listener_handle, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
         if (bind(proxy_context->udp_listener_handle,
                  (struct sockaddr *) &proxy_context->local_sockaddr,
                  proxy_context->local_sockaddr_len) != 0) {


### PR DESCRIPTION
This allows multiple dnscrypt-proxy processes to share a single pair of TCP and UDP ports. This feature only works on Linux v3.9+. The use case is to allow the OS to round-robin DNS requests across multiple dncrypt-proxy processes without complex iptable rules. This doesn't provide fail-over or redundancy, but it does let the user spread their DNS requests across multiple resolvers with minimal effort, just by running more than one process at a time.