### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM gcc
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y libsodium-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD . /src/
+WORKDIR /src/
+
+RUN \
+  ./autogen.sh && \
+  ./configure && \
+  make && \
+  make install
+
+ENTRYPOINT [ "dnscrypt-proxy", "--local-address", "0.0.0.0" ]


### PR DESCRIPTION
Add Dockerfile to enable Docker image building.
Later, automatic builds can be triggered on each commit to publish an official image on Docker Hub:
https://docs.docker.com/docker-hub/builds/

Build:
```
$ docker build -t dnscrypt-proxy .
```

Run:
```
$ docker run -d -it -p 1053:53/udp dnscrypt --resolver-name soltysiak
```

Image based on Docker Hub's official gcc image: https://docs.docker.com/docker-hub/builds/