### PR TITLE
Add --syslog-prefix (-Z) option

### DIFF
--- a/man/dnscrypt-proxy.8.markdown
+++ b/man/dnscrypt-proxy.8.markdown
@@ -83,8 +83,11 @@ ports.
   * `-r`, `--resolver-address=<ip>[:port]`: a DNSCrypt-capable resolver IP
     address with an optional port. The default port is 443.
 
-  * -S, --syslog: if a log file hasn't been set, log diagnostic messages to
+  * `-S`, `--syslog:` if a log file hasn't been set, log diagnostic messages to
     syslog instead of printing them. --daemonize implies --syslog.
+
+  * `-Z`, `--syslog-prefix=prefix`: specify a string of message to insert at
+    the beginning of every line sent to syslog. This implies --syslog.
 
   * `-t`, `--test=<margin>`: don't actually start the proxy, but check that
     a valid certificate can be retrieved from the server and that it

--- a/src/proxy/dnscrypt_proxy.h
+++ b/src/proxy/dnscrypt_proxy.h
@@ -130,6 +130,7 @@ typedef struct ProxyContext_ {
     _Bool                    ephemeral_keys;
     _Bool                    listeners_started;
     _Bool                    syslog;
+    const char              *syslog_prefix;
     _Bool                    tcp_only;
     _Bool                    test_only;
 } ProxyContext;

--- a/src/proxy/logger.c
+++ b/src/proxy/logger.c
@@ -89,7 +89,7 @@ logger(struct ProxyContext_ * const context,
     line[len++] = 0;
 #ifndef _WIN32
     if (context != NULL && context->log_fp == NULL && context->syslog != 0) {
-        syslog(crit, "%s", line);
+        syslog(crit, "%s%s", context->syslog_prefix ? context->syslog_prefix : "", line);
         return 0;
     }
 #endif
@@ -110,7 +110,11 @@ logger(struct ProxyContext_ * const context,
     } else {
         log_fp = context->log_fp;
     }
-    fprintf(log_fp, "%s%s\n", urgency, line);
+    if (context->syslog_prefix) {
+        fprintf(log_fp, "%s%s%s\n", urgency, context->syslog_prefix, line);
+    } else {
+        fprintf(log_fp, "%s%s\n", urgency, line);
+    }
     fflush(log_fp);
 
     return 0;

--- a/src/proxy/options.c
+++ b/src/proxy/options.c
@@ -55,6 +55,7 @@ static struct option getopt_long_options[] = {
     { "resolver-address", 1, NULL, 'r' },
 #ifndef _WIN32
     { "syslog", 0, NULL, 'S' },
+    { "syslog-prefix", 1, NULL, 'Z' },
 #endif
     { "user", 1, NULL, 'u' },
     { "test", 1, NULL, 't' },
@@ -68,7 +69,7 @@ static struct option getopt_long_options[] = {
     { NULL, 0, NULL, 0 }
 };
 #ifndef _WIN32
-static const char *getopt_options = "a:de:Ehk:K:L:l:m:n:p:r:R:St:u:N:TVX:";
+static const char *getopt_options = "a:de:Ehk:K:L:l:m:n:p:r:R:SZ:t:u:N:TVX:";
 #else
 static const char *getopt_options = "a:e:Ehk:K:L:l:m:n:r:R:t:u:N:TVX:";
 #endif
@@ -123,6 +124,7 @@ void options_init_with_default(AppContext * const app_context,
     proxy_context->provider_publickey_s = NULL;
     proxy_context->resolver_ip = NULL;
     proxy_context->syslog = 0;
+    proxy_context->syslog_prefix = NULL;
 #ifndef _WIN32
     proxy_context->user_id = (uid_t) 0;
     proxy_context->user_group = (uid_t) 0;
@@ -569,9 +571,15 @@ options_parse(AppContext * const app_context,
         case 'R':
             proxy_context->resolver_name = optarg;
             break;
+#ifndef _WIN32
         case 'S':
             proxy_context->syslog = 1;
             break;
+        case 'Z':
+            proxy_context->syslog = 1;
+            proxy_context->syslog_prefix = optarg;
+            break;
+#endif
         case 'm': {
             char *endptr;
             const long max_log_level = strtol(optarg, &endptr, 10);


### PR DESCRIPTION
Good day,

When we enable `--syslog` in multiple instances of `dnsscrypt-proxy`, it wouldn't be easy to track specific messages about particular targets written in a syslog file since we only have PID's to distinguish each instance.  But if we have this feature we can customize the messages to become something like this:
```
May 18 09:55:14 local dnscrypt-proxy[6349]: [173.234.159.235:443] Server key fingerprint is ...
May 18 09:55:14 local dnscrypt-proxy[6349]: [173.234.159.235:443] Proxying from 127.0.x.x:5053 to 173.234.159.235:443
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] Starting dnscrypt-proxy 1.6.1
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] Generating a new session key pair
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] Done
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] Server certificate #808464433 received
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] This certificate is valid
May 18 09:55:15 local dnscrypt-proxy[6350]: [172.81.176.146:443] Chosen certificate #808464433 is valid from 
```
So it would be nice if it gets added.