### PR TITLE
Add unbound to the list of dnscrypt servers

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,11 @@ $ minisign -VP RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3 -m &lt;f
                     while shunting or blocking abusive traffic.</p>
 
                 <p>dnsdist <a href="https://github.com/PowerDNS/pdns/blob/master/pdns/README-dnsdist.md#dnscrypt">can act as a DNSCrypt server</a>                    when compiled with <code>--enable-dnscrypt</code>.</p>
+
+                <p><a href="https://www.unbound.net/">unbound</a>, a validating, recursive, and caching DNS resolver, can also act
+                    as a DNSCrypt server when compiled with <code>--enable-dnscrypt</code>.</p>
+
+                <p>Refer to <em>DNSCrypt Options</em> section in <code>unbound.conf(5)</code> for configuration options.</p>
             </section>
         </section>
 


### PR DESCRIPTION
My dnscrypt server patch made it into unbound master with https://github.com/NLnetLabs/unbound/commit/1ec4af38b8af63d2525ee999bf02a9d1ac31c79c . It may be better to wait for the next release cut to update the index page, but I figured I would get this PR up in the meantime.
