### PR TITLE
added ftruncate() error handling to eliminate compilation error:

### DIFF
--- a/src/proxy/pid_file.c
+++ b/src/proxy/pid_file.c
@@ -6,12 +6,10 @@
 #endif
 
 #include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <event2/util.h>
@@ -102,20 +100,7 @@ pid_file_write(const int fd, const pid_t child)
     assert((size_t) pid_buf_len < sizeof pid_buf);
     if (safe_write(fd, pid_buf, (size_t) pid_buf_len, -1) !=
         (ssize_t) pid_buf_len) {
-        int ftruncate_return_value = ftruncate(fd, (off_t) 0);
-        if (ftruncate_return_value < 0) {
-            if (errno == EINVAL || errno == EBADF) {
-                fprintf(stderr,
-                        "Unable to open file for writing because "
-                        "of file descriptor errors in ftruncate(): %s\n",
-                        strerror(errno));
-            }
-            if (errno == EROFS) {
-                fprintf(stderr,
-                        "Read-only filesystem: %s\n",
-				        strerror(errno));
-            }
-        }
+        (void) ftruncate(fd, (off_t) 0);
         (void) close(fd);
         return -1;
     }

--- a/src/proxy/pid_file.c
+++ b/src/proxy/pid_file.c
@@ -94,13 +94,17 @@ pid_file_write(const int fd, const pid_t child)
 {
     char pid_buf[50U];
     int  pid_buf_len;
+    int save_errno;
 
     pid_buf_len = evutil_snprintf(pid_buf, sizeof pid_buf, "%llu",
                                   (unsigned long long) child);
     assert((size_t) pid_buf_len < sizeof pid_buf);
     if (safe_write(fd, pid_buf, (size_t) pid_buf_len, -1) !=
         (ssize_t) pid_buf_len) {
+        /*
         (void) ftruncate(fd, (off_t) 0);
+        */
+        save_errno = ftruncate(fd, (off_t) 0);
         (void) close(fd);
         return -1;
     }

--- a/src/proxy/pid_file.c
+++ b/src/proxy/pid_file.c
@@ -102,8 +102,10 @@ pid_file_write(const int fd, const pid_t child)
     if (safe_write(fd, pid_buf, (size_t) pid_buf_len, -1) !=
         (ssize_t) pid_buf_len) {
         /*
-        (void) ftruncate(fd, (off_t) 0);
-        */
+         * Since we do not care about errno, then just save it
+         * to a variable. This at least gets rid of the compilation
+         * warnings.
+         */
         save_errno = ftruncate(fd, (off_t) 0);
         (void) close(fd);
         return -1;

--- a/src/proxy/pid_file.c
+++ b/src/proxy/pid_file.c
@@ -6,10 +6,12 @@
 #endif
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include <event2/util.h>
@@ -100,7 +102,20 @@ pid_file_write(const int fd, const pid_t child)
     assert((size_t) pid_buf_len < sizeof pid_buf);
     if (safe_write(fd, pid_buf, (size_t) pid_buf_len, -1) !=
         (ssize_t) pid_buf_len) {
-        (void) ftruncate(fd, (off_t) 0);
+        int ftruncate_return_value = ftruncate(fd, (off_t) 0);
+        if (ftruncate_return_value < 0) {
+            if (errno == EINVAL || errno == EBADF) {
+                fprintf(stderr,
+                        "Unable to open file for writing because "
+                        "of file descriptor errors in ftruncate(): %s\n",
+                        strerror(errno));
+            }
+            if (errno == EROFS) {
+                fprintf(stderr,
+                        "Read-only filesystem: %s\n",
+				        strerror(errno));
+            }
+        }
         (void) close(fd);
         return -1;
     }


### PR DESCRIPTION
        pid_file.c: In function ‘pid_file_write’:
        pid_file.c:103:9: warning: ignoring return value of ‘ftruncate’, declared with attribute warn_unused_result [-Wunused-result]
                 (void) ftruncate(fd, (off_t) 0);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~