### PR TITLE
Add BarbBlock list to domains-blacklist.conf

### DIFF
--- a/contrib/domains-blacklist.conf
+++ b/contrib/domains-blacklist.conf
@@ -79,6 +79,9 @@ http://sysctl.org/cameleon/hosts
 # KAD host file (fraud/adware) - https://github.com/azet12/KADhosts
 https://raw.githubusercontent.com/azet12/KADhosts/master/KADhosts.txt
 
+# BarbBlock list (spurious and invalid DMCA takedowns)
+https://ssl.bblck.me/blacklists/domain-list.txt
+
 # Dan Pollock's hosts list
 http://someonewhocares.org/hosts/hosts
 


### PR DESCRIPTION
[BarbBlock](https://ssl.bblck.me) is a content blocking list that blacklists domains that have used spurious and invalid DMCA takedowns to force removal from other content blocking lists. Originally conceived as a browser extension, it has also been made available as a [domain list](https://ssl.bblck.me/blacklists/domain-list.txt) suitable for domain-level blacklisting.